### PR TITLE
Updating stale reference of libwebp to new repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Vendors/libwebp"]
 	path = Vendors/libwebp
-	url = http://git.chromium.org/webm/libwebp.git
+	url = https://chromium.googlesource.com/webm/libwebp


### PR DESCRIPTION
To update your local development environment with this new path, you need to run 

```
git submodule sync 
```
